### PR TITLE
Introduce Scalac silencer plugin

### DIFF
--- a/src/main/scala/ch/epfl/bluebrain/nexus/sbt/nexus/CompilationPlugin.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/sbt/nexus/CompilationPlugin.scala
@@ -16,6 +16,10 @@ object CompilationPlugin extends AutoPlugin {
   override lazy val trigger = allRequirements
 
   trait Keys {
+    val scalacSilencerVersion = SettingKey[String](
+      "scalac-silencer-version",
+      "Scalac silencer plugin version for annotation-based warning suppression.")
+
     val javaSpecificationVersion = SettingKey[String](
       "java-specification-version",
       "The java specification version to be used for source and target compatibility.")
@@ -36,6 +40,7 @@ object CompilationPlugin extends AutoPlugin {
   override lazy val projectSettings = Seq(
     javaSpecificationVersion := "1.8",
     scalaVersion             := "2.12.4",
+    scalacSilencerVersion    := "0.6",
     scalacCommonFlags        := Seq("-deprecation", "-encoding", "UTF-8", "-feature", "-unchecked", "-Xlint"),
     scalacLanguageFlags := Seq(
       "-language:existentials",
@@ -70,6 +75,10 @@ object CompilationPlugin extends AutoPlugin {
                          "-target",
                          javaSpecificationVersion.value,
                          "-Xlint"),
+    libraryDependencies ++= Seq(
+      compilerPlugin("com.github.ghik" %% "silencer-plugin" % scalacSilencerVersion.value),
+      "com.github.ghik" %% "silencer-lib" % scalacSilencerVersion.value
+    ),
     // fail the build initialization if the JDK currently used is not ${javaSpecificationVersion} or higher
     initialize := {
       // runs the previous initialization

--- a/src/main/scala/ch/epfl/bluebrain/nexus/sbt/nexus/DocumentationPlugin.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/sbt/nexus/DocumentationPlugin.scala
@@ -8,7 +8,7 @@ import sbt._
   * cross linking the scala doc.  The default configuration automatically adds the ''scala library'' to the
   * ''apiMappings''.
   *
-  * @see [[ch.epfl.bluebrain.nexus.sbt.nexus.DocumentationPlugin#mapping]]
+  * @see [[ch.epfl.bluebrain.nexus.sbt.nexus.DocumentationPlugin#apiMappingFor]]
   */
 object DocumentationPlugin extends AutoPlugin {
 


### PR DESCRIPTION
Since we can't use SuppressWarnings annotations to disable Scalac warnings, this does the job (for instance in tests...)